### PR TITLE
Ability to specify multiple data paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,13 +84,18 @@ In this example, we will use the preloaded data files as the seed data to to gen
 The default data builder is set to run with the GenAI api unless overridden. We thus only need to run the following command (run from the root of the repository) to execute data generation with GenAI:
 
 ```command
-python -m fms_dgt.__main__ --data-path ./data/logical_reasoning/causal/qna.yaml
+python -m fms_dgt.__main__ --data-paths ./data/logical_reasoning/causal/qna.yaml
 ```
 
 Alternatively, you can also use the CLI
 
 ```command
-fms_dgt --data-path ./data/logical_reasoning/causal/qna.yaml
+fms_dgt --data-paths ./data/logical_reasoning/causal/qna.yaml
+```
+
+If you want to pass multiple data paths, you can do so
+```command
+fms_dgt --data-paths ./data/logical_reasoning/causal ./data/writing/freeform
 ```
 
 #### Testing with vLLM
@@ -98,7 +103,7 @@ fms_dgt --data-path ./data/logical_reasoning/causal/qna.yaml
 For convenience, we have provided an additional configuration file that can be modified to test out using a local model with vLLM. First, open [the config file](./configs/demo.yaml) and update the model field `model_id_or_path` to substitute the `<local-path-to-model>` variable with the path of a model that has been downloaded locally.
 
 ```command
-python -m fms_dgt.__main__ --data-path ./data/logical_reasoning/causal/qna.yaml --include-config-path ./configs/demo.yaml
+python -m fms_dgt.__main__ --data-paths ./data/logical_reasoning/causal/qna.yaml --include-config-path ./configs/demo.yaml
 ```
 
 **Note:** vLLM [requires Linux OS and CUDA](https://docs.vllm.ai/en/latest/getting_started/installation.html#requirements).

--- a/docs/sdg_design.md
+++ b/docs/sdg_design.md
@@ -178,7 +178,7 @@ inp_lst = [inp]
 The interfaces are as follows:
 
 - `generate_data()`: Generate synthentic data
-  - `data_path` (str): Path to data directory (or data file), this is where all task data will be loaded from
+  - `data_paths` (str): One or more paths to data directory (or data files), this is where all task data will be loaded from
   - `num_outputs_to_generate` (int): Number of outputs to generate
   - `num_prompt_instructions` (int): Number of prompt instructions to generate
   - `max_gen_requests` (int): How many iterations of generation should be attempted
@@ -193,13 +193,18 @@ The interfaces are as follows:
 To call this from the command line use the \_\_main\_\_.py file, e.g.,
 
 ```shell
-python -m fms_dgt.__main__ --data-path ./data/logical_reasoning/causal/qna.yaml
+python -m fms_dgt.__main__ --data-paths ./data/logical_reasoning/causal/qna.yaml
 ```
 
-or to run all files in a directory, just specify the top-level directory
+To run all files in a directory, just specify the top-level directory
 
 ```shell
-python -m fms_dgt.__main__ --data-path ./data/logical_reasoning/
+python -m fms_dgt.__main__ --data-paths ./data/logical_reasoning/
+```
+
+To run specific list of files and/or directories, you can pass multiple data paths
+```shell
+python -m fms_dgt.__main__ --data-paths ./data/logical_reasoning/causal ./data/writing/freeform
 ```
 
 ### Implementation
@@ -214,7 +219,7 @@ from fms_dgt.generate_data import generate_data
 generate_data(
     num_outputs_to_generate=2,
     num_prompt_instructions=2,
-    data_path="data",
+    data_paths=["data"],
     max_gen_requests=2,
     output_dir="output",
     lm_cache=None,

--- a/fms_dgt/__main__.py
+++ b/fms_dgt/__main__.py
@@ -148,6 +148,6 @@ def main():
 
 if __name__ == "__main__":
     """
-    python -m fms_dgt.__main__ --data-path <path-to-data> --lm_cache <path-to-cache>
+    python -m fms_dgt.__main__ --data-paths <path-to-data> --lm_cache <path-to-cache>
     """
     main()

--- a/fms_dgt/__main__.py
+++ b/fms_dgt/__main__.py
@@ -32,20 +32,21 @@ def add_base_args(parser: argparse.ArgumentParser):
         "--include-builder-path",
         "--include-bp",
         type=str,
-        metavar="DIR",
+        metavar="BUILDER_PATH",
         help="Additional path to include if there are new data builders.",
     )
     group.add_argument(
         "--include-config-path",
         type=str,
-        metavar="DIR",
+        metavar="CONFIG_PATH",
         help="Additional path to include if there are overrides for data builder config files.",
     )
     group.add_argument(
-        "--data-path",
+        "--data-paths",
         type=str,
+        nargs="+",
         default=DEFAULT_DATA_PATH,
-        help=f"Path to local data.",
+        help="One or more paths to local data.",
     )
     group.add_argument(
         "--output-dir",

--- a/fms_dgt/generate_data.py
+++ b/fms_dgt/generate_data.py
@@ -1,5 +1,4 @@
 # Standard
-from pathlib import Path
 from typing import Dict, Optional
 import os
 
@@ -13,7 +12,7 @@ sdg_logger = utils.sdg_logger
 
 
 def generate_data(
-    data_path: str,
+    data_paths: str,
     output_dir: str,
     task_kwargs: Dict,
     builder_kwargs: Dict,
@@ -23,20 +22,21 @@ def generate_data(
     restart_generation: bool = False,
 ):
     # TODO: better naming convention...
-    name = (
-        Path(os.path.split(data_path)[0]).stem
-        if os.path.isfile(data_path)
-        else Path(data_path).stem
-    )
+    names = []
+    for data_path in data_paths:
+        names.append(utils.get_data_path_name(data_path))
+    name = "_AND_".join(names)
     output_dir = os.path.join(output_dir, name)
 
     # check data_path first then seed_tasks_path
     # throw an error if both not found
     # pylint: disable=broad-exception-caught,raise-missing-from
-    if data_path and os.path.exists(data_path):
-        task_inits = utils.read_data(data_path, include_data_path)
-    else:
-        raise SystemExit(f"Error: data path ({data_path}) does not exist.")
+    task_inits = []
+    for data_path in data_paths:
+        if data_path and os.path.exists(data_path):
+            task_inits.extend(utils.read_data(data_path, include_data_path))
+        else:
+            raise SystemExit(f"Error: data path ({data_path}) does not exist.")
 
     # gather data builders here
     builder_list = [t["data_builder"] for t in task_inits]

--- a/fms_dgt/generate_data.py
+++ b/fms_dgt/generate_data.py
@@ -1,5 +1,5 @@
 # Standard
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 import os
 
 # Local
@@ -12,7 +12,7 @@ sdg_logger = utils.sdg_logger
 
 
 def generate_data(
-    data_paths: str,
+    data_paths: List[str],
     output_dir: str,
     task_kwargs: Dict,
     builder_kwargs: Dict,

--- a/fms_dgt/utils.py
+++ b/fms_dgt/utils.py
@@ -1,6 +1,7 @@
 # Standard
 from collections import ChainMap
 from typing import Any, Callable, List, TypeVar
+from pathlib import Path
 import collections
 import copy
 import fnmatch
@@ -271,6 +272,22 @@ def merge_dictionaries(*args: List[dict]):
     return merged_dict
 
 
+def get_data_path_name(data_path: str):
+    name = (
+        Path(os.path.split(data_path)[0]).stem
+        if os.path.isfile(data_path)
+        else Path(data_path).stem
+    )
+    return name
+
+
+def sanitize_path(path: str):
+    """
+    Sanitize a path against directory traversals
+    """
+    return os.path.relpath(os.path.normpath(os.path.join("/", path)), "/")
+
+
 # pylint: disable=broad-exception-caught
 def read_data_file(file_path: str):
     if file_path.endswith(".yaml"):
@@ -284,7 +301,7 @@ def read_data_file(file_path: str):
             file_path = file_path[len("." + os.sep) :]
 
         # get seed instruction data
-        task_name = "->".join(os.path.dirname(file_path).split(os.sep))
+        task_name = "->".join(sanitize_path(os.path.dirname(file_path)).split(os.sep))
         data_builder = contents.get("data_builder", "simple")
         created_by = contents.get("created_by", "")
         seed_examples = contents.pop("seed_examples", [dict()])

--- a/fms_dgt/utils.py
+++ b/fms_dgt/utils.py
@@ -285,7 +285,7 @@ def sanitize_path(path: str):
     """
     Sanitize a path against directory traversals
     """
-    return os.path.relpath(os.path.normpath(os.path.join("/", path)), "/")
+    return os.path.relpath(os.path.normpath(os.path.join(os.sep, path)), os.sep)
 
 
 # pylint: disable=broad-exception-caught

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,17 @@
+# Third Party
+import pytest
+
+# Local
+from fms_dgt.utils import sanitize_path
+
+
+def test_sanitize_path():
+    assert sanitize_path("../test") == "test"
+    assert sanitize_path("../../test") == "test"
+    assert sanitize_path("../../abc/../test") == "test"
+    assert sanitize_path("../../abc/../test/fixtures") == "test/fixtures"
+    assert sanitize_path("../../abc/../.test/fixtures") == ".test/fixtures"
+    assert sanitize_path("/test/foo") == "test/foo"
+    assert sanitize_path("./test/bar") == "test/bar"
+    assert sanitize_path(".test/baz") == ".test/baz"
+    assert sanitize_path("qux") == "qux"


### PR DESCRIPTION
## What this PR does / why we need it
1. Certain use cases benefit from specifying seed data in different sub-branches of a taxonomy. Current implementation only allows the user to specify one data path. With this change we can specify one or more data paths. 
`--data-path` --> `--data-paths`

Example usage:

```
fms_dgt --data-paths ./data/logical_reasoning/causal ./data/writing/freeform --num-outputs-to-generate 100
```

2. Sanitize file paths before initializing task names. When specifying data paths relative to the root directory (eg., `--data-path ../data/common_sense_reasoning`), the framework creates subdirectories like `..->..->data->common_sense_reasoning` and these get hidden by the OS and hence not searchable or readable. By sanitizing the paths, we can prevent this. 
 
Ref: https://stackoverflow.com/questions/13939120/sanitizing-a-file-path-in-python

## Special notes for your reviewer

## If applicable**
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
