### PR TITLE
two args to generate_data never passed

### DIFF
--- a/data/generation/logical_reasoning/causal/qnastar.yaml
+++ b/data/generation/logical_reasoning/causal/qnastar.yaml
@@ -1,0 +1,33 @@
+created_by: IBM
+data_builder: simple* # this causes a crash
+seed_examples:
+  - answer:
+      "While days tend to be longer in the summer, just because it is not summer
+      doesn't mean days are necessarily shorter.
+
+      "
+    question:
+      "If it is summer, then the days are longer. Are the days longer if it
+      is not summer ?
+
+      "
+  - answer:
+      'No, we cannot conclusively conclude that some cats are black based solely
+      on the given premises. The statement "some mammals are black" does not necessarily
+      guarantee that among those mammals are cats.
+
+      '
+    question:
+      If all cats are mammals and some mammals are black, can we conclude that
+      some cats are black?
+  - answer:
+      "Yes, we can conclude that all squares have four sides based on the given
+      premises.
+
+      "
+    question:
+      "If all squares are rectangles and a rectangle has four sides, can we
+      conclude that all squares have four sides?
+
+      "
+task_description: To teach a language model about Logical Reasoning - causal relationships

--- a/fms_dgt/generate_data.py
+++ b/fms_dgt/generate_data.py
@@ -16,11 +16,12 @@ def generate_data(
     output_dir: str,
     task_kwargs: Dict,
     builder_kwargs: Dict,
-    include_data_path: Optional[str] = None,
     include_config_paths: Optional[List[str]] = None,
     include_builder_paths: Optional[List[str]] = None,
-    restart_generation: bool = False,
 ):
+    include_data_path: Optional[str] = None
+    restart_generation: bool = False
+
     # TODO: better naming convention...
     names = []
     for data_path in data_paths:
@@ -46,13 +47,21 @@ def generate_data(
     )
     builder_names = builder_index.match_builders(builder_list)
     sdg_logger.debug("All builders: %s", builder_names)
-    for builder in [
-        builder for builder in builder_list if builder not in builder_names
-    ]:
-        if os.path.isfile(builder):
-            config = utils.load_yaml_config(builder)
-            builder_names.append(config)
+    builder_missing = set()
+    for builder in builder_list:
+        if builder not in builder_names:
+            if os.path.isfile(builder):
+                config = utils.load_yaml_config(builder)
+                builder_names.append(config)
+            else:
+                builder_missing.add(builder)
 
+    if builder_missing:
+        missing = ", ".join(builder_missing)
+        print("This test works")
+        print(ValueError(f"Builder specifications not found: [{missing}]"))
+
+    # this doesn't detect e.g. "simple*", leading to a crash
     builder_missing = set(
         [
             builder


### PR DESCRIPTION
include_data_path is not an arg
verify using:
rg 'include.*data' fms-dgt/fms_dgt/__main__.py

restart_generation is a "task" arg, so is not passed as a "base" arg

The restart_generation field of the task object can apparently be set, since it seems to use the task_kwargs data to initialize its fields, but it is very difficult to trace this code, and I can't see how these objects are created

The test for missing builders does not work for the something like "simple*", as shown by the qnastar.yaml config file.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/foundation-model-stack/fms-sdg/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

## Related Issue
Supports #ISSUE_NUMBER

## Related PRs
This PR is not dependent on any other PR

## What this PR does / why we need it

## Special notes for your reviewer

## If applicable**
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
