### PR TITLE
feat: update naming of output folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ python -m fms_dgt.__main__ --data-paths ./data/generation/logical_reasoning/caus
 
 #### Examine Outputs
 
-The generated data will be output to the following directory: `output/causal/data->logical_reasoning->causal/generated_instructions.json`
+The generated data will be output to the following directory: `output/causal/data__logical_reasoning__causal/generated_instructions.json`
 
 This example uses the `SimpleInstructDataBuilder` as defined in `./fms_dgt/databuilders/generation/simple/`. For more information on data builders and other components of Scalable SDG, take a look at the [SDG Design](./docs/sdg_design.md) doc.
 

--- a/fms_dgt/datastores/default.py
+++ b/fms_dgt/datastores/default.py
@@ -58,7 +58,7 @@ class DefaultDatastore(BaseDatastore):
     def _get_default_output_dir(self, output_dir: str, task_name: str):
         path_components = []
         path_components.append(output_dir)
-        path_components.append(task_name)
+        path_components.append(task_name.replace("->", "__"))
         return os.path.join(*path_components)
 
     def save_data(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "rouge-score>=0.0.4",
     "scikit-learn>=0.24.1",
     "sqlitedict",
-    "torch>=2.2",
+    "torch>=2.3",
     "tqdm-multiprocess",
     "transformers>=4.1",
     "tabulate>=0.9",


### PR DESCRIPTION
## What this PR does / why we need it
Output folders will be now named `output/causal/data__logical_reasoning__causal/generated_instructions.json` instead of `output/causal/data->logical_reasoning->causal/generated_instructions.json`

## Special notes for your reviewer

## If applicable**
- [x] this PR contains documentation
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
