### PR TITLE
Fix cl/config argument conflict

### DIFF
--- a/fms_dgt/base/databuilder.py
+++ b/fms_dgt/base/databuilder.py
@@ -130,7 +130,7 @@ class DataBuilder(ABC):
 
     def _init_tasks(self, task_inits: dict, task_kwargs: dict):
         self._tasks: List[SdgTask] = [
-            self.TASK_TYPE(builder_cfg=self._config, **task_init, **task_kwargs)
+            self.TASK_TYPE(builder_cfg=self._config, **{**task_init, **task_kwargs})
             for task_init in task_inits
         ]
 


### PR DESCRIPTION
## What this PR does / why we need it

Fixes the case where parameters defined in the config duplicate command line defaults and there is double definition error.

## Special notes for your reviewer

## If applicable**
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
