### PR TITLE
Datastore simplification

### DIFF
--- a/data/transformation/apis/atis/qna.yaml
+++ b/data/transformation/apis/atis/qna.yaml
@@ -3,7 +3,7 @@ data_builder: transform_api_snips_atis
 instruction_format:
   input: "SYSTEM: You are a helpful assistant with access to the following function calls. Your task is to produce a sequence of function calls necessary to generate response to the user utterance. Use the following function calls as required and return only function \"name\" with empty \"arguments\" dictionary in your response.\n<|function_call_library|>\n{{api_specifications}}\n\nUSER: {{input}}\nASSISTANT: "
   output: "{{output}}"
-datastore:
+seed_datastore:
   type: api_snips_atis_transform_datastore
   data_path: data/transformation/apis/atis/MixATIS_clean
   splits: [train, dev] # [train, test, dev]

--- a/data/transformation/apis/dstc8/qna.yaml
+++ b/data/transformation/apis/dstc8/qna.yaml
@@ -3,7 +3,7 @@ data_builder: transform_api_llm
 instruction_format:
   input: "SYSTEM: You are a helpful assistant with access to the following function calls. Your task is to produce a sequence of function calls necessary to generate response to the user utterance. Use the following function calls as required and return only function \"name\" with empty \"arguments\" dictionary in your response.\n<|function_call_library|>\n{{api_specifications}}\n\nUSER: {{input}}\nASSISTANT: "
   output: "{{output}}"
-datastore:
+seed_datastore:
   type: api_llm_transform_datastore
   data_path: data/transformation/apis/dstc8/dstc8-schema-guided-dialogue-master
   splits: [train, dev] # [train, test, dev]

--- a/data/transformation/apis/multiwoz/qna.yaml
+++ b/data/transformation/apis/multiwoz/qna.yaml
@@ -3,7 +3,7 @@ data_builder: transform_api_llm
 instruction_format:
   input: "SYSTEM: You are a helpful assistant with access to the following function calls. Your task is to produce a sequence of function calls necessary to generate response to the user utterance. Use the following function calls as required and return only function \"name\" with empty \"arguments\" dictionary in your response.\n<|function_call_library|>\n{{api_specifications}}\n\nUSER: {{input}}\nASSISTANT: "
   output: "{{output}}"
-datastore:
+seed_datastore:
   type: api_llm_transform_datastore
   data_path: data/transformation/apis/multiwoz/MultiWOZ_2.2
   splits: [train, dev] # [train, test, dev]

--- a/data/transformation/apis/snips/qna.yaml
+++ b/data/transformation/apis/snips/qna.yaml
@@ -3,7 +3,7 @@ data_builder: transform_api_snips_atis
 instruction_format:
   input: "SYSTEM: You are a helpful assistant with access to the following function calls. Your task is to produce a sequence of function calls necessary to generate response to the user utterance. Use the following function calls as required and return only function \"name\" with empty \"arguments\" dictionary in your response.\n<|function_call_library|>\n{{api_specifications}}\n\nUSER: {{input}}\nASSISTANT: "
   output: "{{output}}"
-datastore:
+seed_datastore:
   type: api_snips_atis_transform_datastore
   data_path: data/transformation/apis/snips/MixSNIPS_clean
   splits: [train, dev] # [train, test, dev]

--- a/data/transformation/apis/topv2/qna.yaml
+++ b/data/transformation/apis/topv2/qna.yaml
@@ -3,7 +3,7 @@ data_builder: transform_api_topv2
 instruction_format:
   input: "SYSTEM: You are a helpful assistant with access to the following function calls. Your task is to produce a sequence of function calls necessary to generate response to the user utterance. Use the following function calls as required and return only function \"name\" with empty \"arguments\" dictionary in your response.\n<|function_call_library|>\n{{api_specifications}}\n\nUSER: {{input}}\nASSISTANT: "
   output: "{{output}}"
-datastore:
+seed_datastore:
   type: api_topv2_transform_datastore
   data_path: data/transformation/apis/topv2/TOPv2_Dataset
   splits: [train, dev] # [train, test, dev]

--- a/fms_dgt/__main__.py
+++ b/fms_dgt/__main__.py
@@ -110,6 +110,11 @@ def add_task_args(parser: argparse.ArgumentParser):
         default=DEFAULT_GENERATED_FILES_OUTPUT_DIR,
         help="Path to output generated files.",
     )
+    group.add_argument(
+        "--exec-id",
+        type=str,
+        help="ID of entity executing experiment.",
+    )
     return group
 
 

--- a/fms_dgt/base/databuilder.py
+++ b/fms_dgt/base/databuilder.py
@@ -180,10 +180,6 @@ class DataBuilder(ABC):
         completed_tasks = [task for task in tasks if task.is_complete()]
         tasks = [task for task in tasks if task not in completed_tasks]
 
-        # save task details for incomplete tasks
-        for task in tasks:
-            task.save_task()
-
         progress_bar = tqdm(total=len(tasks), desc="Running generation tasks")
         generate_start = time.time()
 
@@ -310,10 +306,6 @@ class TransformationDataBuilder(DataBuilder):
                 task, TransformTask
             ), f"Task {task.name} must inherit from TransformTask class to be used with TransformationDataBuilder"
             task.load_dataloader_state()
-
-        # save task details for incomplete tasks
-        for task in tasks:
-            task.save_task()
 
         progress_bar = tqdm(total=len(tasks), desc="Running transformation tasks")
         generate_start = time.time()

--- a/fms_dgt/base/dataloader.py
+++ b/fms_dgt/base/dataloader.py
@@ -10,21 +10,11 @@ class BaseDataloader(abc.ABC):
         """Takes data from datastore object and produces one example to be used by SDG process."""
         super().__init__()
 
-    def get_state(self) -> Any:
-        """Gets the state of the dataloader, which influences __next__ function
+    def save_state(self) -> None:
+        """Saves the state of the dataloader which influences the __next__ function"""
 
-        Returns:
-            Any: Dataloader state
-        """
-        pass
-
-    def set_state(self, state: Any) -> None:
-        """Sets the state of the dataloader, which influences __next__ function
-
-        Args:
-            state (Any): Dataloader state
-        """
-        pass
+    def load_state(self) -> None:
+        """Loads the state of the dataloader and sets it which influences the __next__ function"""
 
     @abc.abstractmethod
     def __next__(self) -> Any:

--- a/fms_dgt/base/dataloader.py
+++ b/fms_dgt/base/dataloader.py
@@ -10,11 +10,15 @@ class BaseDataloader(abc.ABC):
         """Takes data from datastore object and produces one example to be used by SDG process."""
         super().__init__()
 
-    def save_state(self) -> None:
-        """Saves the state of the dataloader which influences the __next__ function"""
+    def get_state(self) -> Any:
+        """Gets the state of the dataloader which influences the __next__ function"""
 
-    def load_state(self) -> None:
-        """Loads the state of the dataloader and sets it which influences the __next__ function"""
+    def set_state(self, state: Any) -> None:
+        """Sets the state of the dataloader which influences the __next__ function
+
+        Args:
+            state (Any): object representing state of dataloader
+        """
 
     @abc.abstractmethod
     def __next__(self) -> Any:

--- a/fms_dgt/base/datastore.py
+++ b/fms_dgt/base/datastore.py
@@ -5,8 +5,6 @@ import abc
 # Local
 from fms_dgt.base.block import DATASET_TYPE
 
-DATA_PATH_KEY = "data_path"
-
 
 class BaseDatastore(abc.ABC):
     """Base Class for all data stores"""

--- a/fms_dgt/base/datastore.py
+++ b/fms_dgt/base/datastore.py
@@ -1,89 +1,39 @@
 # Standard
-from typing import Any, List, TypeVar
+from typing import Any
 import abc
 
-DATA_PATH_KEY = "data_path"
+# Local
+from fms_dgt.base.block import DATASET_TYPE
 
-T = TypeVar("T")
+DATA_PATH_KEY = "data_path"
 
 
 class BaseDatastore(abc.ABC):
     """Base Class for all data stores"""
 
-    def __init__(self, **kwargs: Any) -> None:
+    def __init__(self, store_name: str, **kwargs: Any) -> None:
         super().__init__()
+        self._store_name = store_name
 
-    def save_data(self, new_data: List[T]) -> None:
+    @property
+    def store_name(self):
+        return self._store_name
+
+    def save_data(self, new_data: DATASET_TYPE) -> None:
         """
         Saves generated data to specified location
 
         Args:
-            new_data (List[T]): A list of data items to be saved
+            new_data (DATASET_TYPE): A list of data items to be saved
         """
         raise NotImplementedError
 
     def load_data(
         self,
-    ) -> List[T]:
+    ) -> DATASET_TYPE:
         """Loads generated data from save location.
 
         Returns:
-            A list of generated data of type T.
+            A list of generated data of type DATASET_TYPE.
         """
         raise NotImplementedError
-
-    def load_dataset(
-        self,
-    ) -> List[T]:
-        """Loads dataset from specified source
-
-        Returns:
-            List[T]: Dataset object to be used as seed examples
-        """
-        raise NotImplementedError
-
-    def save_task(
-        self,
-    ) -> None:
-        """Default method for saving task specification"""
-        raise NotImplementedError
-
-    def load_task(
-        self,
-    ) -> Any:
-        """Default method for loading task specification
-
-        Returns:
-            Any: Task specification
-        """
-        raise NotImplementedError
-
-    def save_state(self, state: Any) -> None:
-        """Saves a state object that can be used to restore an object (e.g., a dataloader) to a previous state
-
-        Args:
-            state (Any): State object
-        """
-        pass
-
-    def load_state(
-        self,
-    ) -> Any:
-        """Loads the state object
-
-        Returns:
-            Any: State object
-        """
-        pass
-
-    def save_instruction_data(self, new_data: List[T]) -> None:
-        """Saves instruction data to specified location
-
-        Args:
-            new_data (List[T]): List of data to save
-        """
-        pass
-
-    def save_log_data(self, **kwargs):
-        """Saves data regarding run information"""
-        pass

--- a/fms_dgt/base/experiment_card.py
+++ b/fms_dgt/base/experiment_card.py
@@ -1,0 +1,28 @@
+# Standard
+from dataclasses import asdict, dataclass
+from typing import Optional
+import uuid
+
+_DEFAULT_EXEC_ID = "user"
+
+
+@dataclass
+class ExperimentCard:
+    """This class is intended to hold the all information regarding the experiment being run"""
+
+    task_name: str  # name of task
+    task_spec: str  # json string capturing all of task settings
+    databuilder_spec: str  # json string capturing all of databuilder settings
+    exec_id: Optional[
+        str
+    ] = None  # id of entity executing the task (defaults to something generic)
+    run_id: Optional[str] = None  # unique ID for the experiment
+
+    def __post_init__(self):
+        if self.run_id is None:
+            self.run_id = str(uuid.uuid4())
+        if self.exec_id is None:
+            self.exec_id = _DEFAULT_EXEC_ID
+
+    def to_dict(self):
+        return asdict(self)

--- a/fms_dgt/base/registry.py
+++ b/fms_dgt/base/registry.py
@@ -225,7 +225,7 @@ def register_dataloader(*names):
     return decorate
 
 
-def get_dataloader(dataloader_name, *args: Any, **kwargs: Any):
+def get_dataloader(dataloader_name, *args: Any, **kwargs: Any) -> BaseDataloader:
     if dataloader_name not in DATALOADER_REGISTRY:
         _dynamic_registration_import("register_dataloader", dataloader_name)
 
@@ -264,7 +264,7 @@ def register_datastore(*names):
     return decorate
 
 
-def get_datastore(datastore_name, *args: Any, **kwargs: Any):
+def get_datastore(datastore_name, *args: Any, **kwargs: Any) -> BaseDatastore:
     if datastore_name not in DATASTORE_REGISTRY:
         _dynamic_registration_import("register_datastore", datastore_name)
 

--- a/fms_dgt/base/task.py
+++ b/fms_dgt/base/task.py
@@ -192,13 +192,13 @@ class SdgTask:
             self._seed_datastore_cfg.get(TYPE_KEY), **seed_ds_kwargs
         )
 
-        # init dataloader state datastore (should be same as seed datastore)
+        # init dataloader state datastore (should be same as base datastore)
         dls_ds_kwargs = {
             "store_name": os.path.join(self._store_name, "dataloader_state"),
-            **self._seed_datastore_cfg,
+            **self._datastore_cfg,
         }
         self._dataloader_state_datastore = get_datastore(
-            self._seed_datastore_cfg.get(TYPE_KEY), **dls_ds_kwargs
+            self._datastore_cfg.get(TYPE_KEY), **dls_ds_kwargs
         )
 
         # init dataloader itself

--- a/fms_dgt/base/task.py
+++ b/fms_dgt/base/task.py
@@ -227,6 +227,15 @@ class SdgTask:
             self._datastore_cfg.get(TYPE_KEY), **final_ds_kwargs
         )
 
+        # init logging datastore
+        logging_ds_kwargs = {
+            "store_name": os.path.join(self._store_name, "logging"),
+            **self._datastore_cfg,
+        }
+        self._logging_datastore = get_datastore(
+            self._datastore_cfg.get(TYPE_KEY), **logging_ds_kwargs
+        )
+
     def instantiate_input_example(self, **kwargs: Any) -> INPUT_DATA_TYPE:
         """Instantiate an input example for this task. Designed to be overridden with custom initialization.
 
@@ -358,7 +367,9 @@ class SdgTask:
 
     def save_log_data(self) -> None:
         """Saves any Logging information to the datastore."""
-        pass
+        # TODO: populate this with all log data
+        log_data = dict()
+        self._logging_datastore.save_data([log_data])
 
 
 ###

--- a/fms_dgt/base/task.py
+++ b/fms_dgt/base/task.py
@@ -1,13 +1,14 @@
 # Standard
 from dataclasses import asdict, dataclass
-from typing import Any, Dict, List, Mapping, Optional, TypeVar, Union
+from typing import Any, Dict, List, Optional, TypeVar, Union
 import abc
+import os
 import random
 
 # Local
+from fms_dgt.base.datastore import BaseDatastore
+from fms_dgt.base.experiment_card import ExperimentCard
 from fms_dgt.base.registry import get_dataloader, get_datastore
-from fms_dgt.dataloaders.default import DefaultDataloader
-from fms_dgt.datastores.default import DefaultDatastore
 from fms_dgt.utils import group_data_by_attribute
 
 DEFAULT_OUTPUT_DIR = "output"
@@ -23,7 +24,7 @@ class SdgData(abc.ABC):
 
     task_name: str
 
-    def to_output_dict(self) -> Dict:
+    def to_dict(self) -> Dict:
         """Returns output dictionary representation of dataclass. Designed to be overridden with custom logic.
 
         Returns:
@@ -46,14 +47,13 @@ class SdgTask:
         task_description: str,
         created_by: str,
         data_builder: str,
+        experiment_card: ExperimentCard,
         instruction_format: Optional[Dict[str, str]] = None,
         output_dir: Optional[str] = "output",
         output_format: Optional[str] = "jsonl",
         datastore: Optional[Dict] = None,
+        seed_datastore: Optional[Dict] = None,
         restart_generation: Optional[bool] = False,
-        builder_cfg: Optional[Mapping] = None,
-        builder_dir: Optional[str] = None,
-        file_path: Optional[str] = None,
         dataloader: Optional[Dict] = None,
         seed_batch_size: Optional[int] = None,
         machine_batch_size: Optional[int] = None,
@@ -67,13 +67,13 @@ class SdgTask:
             task_description (str): A description of the SDG task is designed to solve.
             created_by (str): The name of the individual / group who created the code assistant.
             data_builder (str): The name of the data builder that should be used to process this task.
+            experiment_card (ExperimentCard): The experiment card containing all experiment information
             instruction_format (Optional[Dict[str, str]]): A dictionary template that can be used to translate intermediate data objects to instruction-tuning pairs
             output_dir (Optional[str]): The directory where the generated outputs will be saved.
             output_format (Optional[str]): The format of the file where generated outputs are saved.
             datastore (Optional[Dict]): A dictionary containing the configuration for the datastore.
+            seed_datastore (Optional[Dict]): A dictionary containing the configuration for the seed datastore.
             restart_generation (Optional[bool]): A boolean indicating whether to restart generation from scratch.
-            builder_cfg (Optional[Mapping]): A dictionary containing the configuration for the data builder.
-            file_path (Optional[str]): The path to the task file.
             dataloader (Optional[Dict]): A dictionary containing the configuration for the dataloader.
             seed_batch_size (Optional[int]): The batch size used for seed examples.
             machine_batch_size (Optional[int]): The batch size used for machine examples.
@@ -85,85 +85,60 @@ class SdgTask:
         self._task_description = task_description
         self._created_by = created_by
         self._data_builder = data_builder
+        self._experiment_card = experiment_card
         self._restart_generation = restart_generation
-        self._file_path = file_path
-        self._builder_cfg = builder_cfg
-        self._builder_dir = builder_dir
         self._seed_examples = seed_examples
         self._num_outputs_to_generate = num_outputs_to_generate
         self._output_format = output_format
         self._output_dir = output_dir
         self._instruction_format = instruction_format
 
-        # dataloader params
-        self._dataloader_cfg = dataloader
-
-        # datastore params
-        self._datastore_cfg = datastore
+        self._store_name = os.path.join(
+            self._experiment_card.task_name, self._experiment_card.exec_id
+        )
 
         self.machine_data = []
 
-        self._seed_batch_size = (
-            seed_batch_size if seed_batch_size is not None else 10000000
-        )
+        self._seed_batch_size = seed_batch_size if seed_batch_size is not None else 100
         if self._seed_batch_size < 0:
             raise ValueError(
                 f"Cannot have negative value of {self._seed_batch_size} for seed_batch_size parameter"
             )
 
         self._machine_batch_size = (
-            machine_batch_size if machine_batch_size is not None else 10000000
+            machine_batch_size if machine_batch_size is not None else 100
         )
         if self._machine_batch_size < 0:
             raise ValueError(
                 f"Cannot have negative value of {self._machine_batch_size} for machine_batch_size parameter"
             )
 
-        self.init_datastore()
-        self.init_dataloader()
+        # dataloader params
+        self._dataloader_cfg = (
+            dataloader if dataloader is not None else {TYPE_KEY: "default"}
+        )
 
-    def init_datastore(self) -> None:
-        """Initialize datastore object for storing all SDG data."""
-
-        ds_kwargs = {
-            "store_name": self._name,
-            "data_builder": self._data_builder,
+        # datastore params
+        base_store_cfg = {
             "restart": self._restart_generation,
-            "file_path": self._file_path,
-            "builder_cfg": self._builder_cfg,
-            "builder_dir": self._builder_dir,
-            "seed_examples": self._seed_examples,
             "output_dir": self._output_dir,
-            "output_format": self._output_format,
         }
-        if self._datastore_cfg is None:
-            self._datastore = DefaultDatastore(
-                **ds_kwargs,
-            )
-        else:
-            assert (
-                TYPE_KEY in self._datastore_cfg
-            ), f"Must specify data store type with '{TYPE_KEY}' key"
-            self._datastore = get_datastore(
-                self._datastore_cfg.get(TYPE_KEY),
-                **{**ds_kwargs, **self._datastore_cfg},
-            )
+        self._datastore_cfg = {
+            **base_store_cfg,
+            **(datastore if datastore is not None else {TYPE_KEY: "default"}),
+        }
+        self._seed_datastore_cfg = {
+            **base_store_cfg,
+            **(seed_datastore if seed_datastore is not None else {TYPE_KEY: "default"}),
+        }
+        self._exp_card_datastore_cfg = {**base_store_cfg, **self._datastore_cfg}
 
-    def init_dataloader(self):
-        """Initialize the dataloader that passes all examples to SDG process."""
+        self._datastore: BaseDatastore = None
+        self._final_datastore: BaseDatastore = None
 
-        if self._dataloader_cfg is None:
-            self._dataloader = DefaultDataloader(datastore=self._datastore)
-        else:
-            assert TYPE_KEY in self._dataloader_cfg, (
-                "Must specify dataloader type with %s key",
-                TYPE_KEY,
-            )
-            self._dataloader = get_dataloader(
-                self._dataloader_cfg.get(TYPE_KEY),
-                datastore=self._datastore,
-                **self._dataloader_cfg,
-            )
+        self._save_exp_card()
+        self._init_dataloader()
+        self._init_datastores()
 
     @property
     def name(self) -> str:
@@ -182,6 +157,75 @@ class SdgTask:
             str: Task description
         """
         return self._task_description
+
+    def _save_exp_card(self):
+        """Saves experiment card to datastore."""
+
+        exp_ds_kwargs = {
+            "store_name": os.path.join(self._store_name, "experiment_card"),
+            **self._exp_card_datastore_cfg,
+        }
+        exp_card_datastore = get_datastore(exp_ds_kwargs.get(TYPE_KEY), **exp_ds_kwargs)
+
+        if not self._restart_generation:
+            prev_exp_cards: List[Dict] = exp_card_datastore.load_data()
+            if prev_exp_cards:
+                self._experiment_card.run_id = ExperimentCard(
+                    **prev_exp_cards[-1]
+                ).run_id
+
+        exp_card_datastore.save_data([self._experiment_card.to_dict()])
+
+    def _init_dataloader(self) -> None:
+        """Initialize datastore object for storing all SDG data."""
+
+        # init seed datastore for dataloader
+        seed_ds_kwargs = {
+            "store_name": os.path.join(self._store_name, "seed_data"),
+            "examples": self._seed_examples,
+            **self._seed_datastore_cfg,
+            "restart": False,
+        }
+        seed_datastore = get_datastore(
+            self._seed_datastore_cfg.get(TYPE_KEY), **seed_ds_kwargs
+        )
+
+        # init dataloader state datastore (should be same as seed datastore)
+        dls_ds_kwargs = {
+            "store_name": os.path.join(self._store_name, "dataloader_state"),
+            **self._seed_datastore_cfg,
+        }
+        dataloader_state_datastore = get_datastore(
+            self._seed_datastore_cfg.get(TYPE_KEY), **dls_ds_kwargs
+        )
+
+        # init dataloader itself
+        self._dataloader = get_dataloader(
+            self._dataloader_cfg.get(TYPE_KEY),
+            data=seed_datastore.load_data(),
+            state_datastore=dataloader_state_datastore,
+            **self._dataloader_cfg,
+        )
+
+    def _init_datastores(self):
+
+        # init input/output datastore
+        io_ds_kwargs = {
+            "store_name": os.path.join(self._store_name, "data"),
+            **self._datastore_cfg,
+        }
+        self._datastore = get_datastore(
+            self._datastore_cfg.get(TYPE_KEY), **io_ds_kwargs
+        )
+
+        # init final output datastore (should be same as input/output datastore)
+        final_ds_kwargs = {
+            "store_name": os.path.join(self._store_name, "final_data"),
+            **self._datastore_cfg,
+        }
+        self._final_datastore = get_datastore(
+            self._datastore_cfg.get(TYPE_KEY), **final_ds_kwargs
+        )
 
     def instantiate_input_example(self, **kwargs: Any) -> INPUT_DATA_TYPE:
         """Instantiate an input example for this task. Designed to be overridden with custom initialization.
@@ -280,7 +324,7 @@ class SdgTask:
         if type(new_data) != list:
             new_data: List[SdgData] = [new_data]
 
-        to_save = [d if type(d) == dict else d.to_output_dict() for d in new_data]
+        to_save = [d if type(d) == dict else d.to_dict() for d in new_data]
         self._datastore.save_data(to_save)
 
     def load_intermediate_data(self) -> List[SdgData]:
@@ -304,28 +348,17 @@ class SdgTask:
                     instruction = self.instantiate_instruction(
                         self.instantiate_output_example(**d)
                     )
-                    self._datastore.save_instruction_data([instruction])
+                    self._final_datastore.save_data([instruction])
 
-    def save_dataloader_state(self) -> None:
-        """Saves state of data loader to enable resumption of SDG process later on."""
-        self._datastore.save_state(self._dataloader.get_state())
+    def save_dataloader_state(self):
+        self._dataloader.save_state()
 
-    def load_dataloader_state(self) -> None:
-        """Loads state of data loader to enable resumption of SDG process."""
-        if not self._restart_generation:
-            self._dataloader.set_state(self._datastore.load_state())
-
-    def save_task(self) -> None:
-        """Saves task specification to datastore."""
-        self._datastore.save_task()
-
-    def load_task(self) -> Any:
-        """Loads task specification from datastore."""
-        return self._datastore.load_task()
+    def load_dataloader_state(self):
+        self._dataloader.load_state()
 
     def save_log_data(self) -> None:
         """Saves any Logging information to the datastore."""
-        return self._datastore.save_log_data()
+        pass
 
 
 ###
@@ -337,23 +370,22 @@ class TransformTask(SdgTask):
     """TransformTask is a subclass of SdgTask that has default values that are more conducive to transformation tasks."""
 
     def __init__(
-        self, *args, seed_batch_size: int = 10, machine_batch_size: int = 0, **kwargs
+        self,
+        *args,
+        dataloader: Optional[Dict] = None,
+        seed_batch_size: int = 10,
+        machine_batch_size: int = 0,
+        **kwargs,
     ):
+        if dataloader is None:
+            dataloader = {TYPE_KEY: "default", "loop_over_data": False}
         super().__init__(
             *args,
+            dataloader=dataloader,
             seed_batch_size=seed_batch_size,
             machine_batch_size=machine_batch_size,
             **kwargs,
         )
-
-    def init_dataloader(self):
-        """Initializes dataloader object for transform tasks."""
-        if self._dataloader_cfg is None:
-            self._dataloader = DefaultDataloader(
-                datastore=self._datastore, loop_over_data=False
-            )
-        else:
-            super().init_dataloader()
 
 
 T = TypeVar("T")

--- a/fms_dgt/base/task.py
+++ b/fms_dgt/base/task.py
@@ -184,7 +184,7 @@ class SdgTask:
         # init seed datastore for dataloader
         seed_ds_kwargs = {
             "store_name": os.path.join(self._store_name, "seed_data"),
-            "examples": self._seed_examples,
+            "data": self._seed_examples,
             **self._seed_datastore_cfg,
             "restart": False,
         }

--- a/fms_dgt/base/task.py
+++ b/fms_dgt/base/task.py
@@ -94,7 +94,8 @@ class SdgTask:
         self._instruction_format = instruction_format
 
         self._store_name = os.path.join(
-            self._experiment_card.task_name, self._experiment_card.exec_id
+            self._experiment_card.exec_id,
+            self._experiment_card.task_name,
         )
 
         self.machine_data = []

--- a/fms_dgt/databuilders/generation/api/task.py
+++ b/fms_dgt/databuilders/generation/api/task.py
@@ -36,7 +36,7 @@ class ApiSdgData(SdgData):
         ) = (None, None, None, None, None)
         return new_instr
 
-    def to_output_dict(self):
+    def to_dict(self):
         output = asdict(self)
         output["api_specifications"] = None
         return output

--- a/fms_dgt/databuilders/transformation/api/task.py
+++ b/fms_dgt/databuilders/transformation/api/task.py
@@ -146,7 +146,7 @@ class ApiTransformDatastore(DefaultDatastore):
         self._splits = splits
         self._extract_fn = extract_fn
 
-    def load_dataset(self) -> List[Dict]:
+    def load_data(self) -> List[Dict]:
         raw_data = []
         for split in self._splits:
             sdg_logger.info("======= %s =======", split)
@@ -172,7 +172,7 @@ class ApiLlmTransformDatastore(ApiTransformDatastore):
 class ApiTopv2TransformDatastore(ApiTransformDatastore):
     """Api transform datastore"""
 
-    def load_dataset(self) -> List[Dict]:
+    def load_data(self) -> List[Dict]:
         raw_data = extract_raw_topv2_data(self._data_path)
         return raw_data
 

--- a/fms_dgt/dataloaders/default.py
+++ b/fms_dgt/dataloaders/default.py
@@ -26,13 +26,11 @@ class DefaultDataloader(BaseDataloader):
         self._i = 0
         self._loop_over_data = loop_over_data
 
-    def save_state(self) -> None:
-        self._state_datastore.save_data([self._i])
+    def get_state(self) -> Any:
+        return self._i
 
-    def load_state(self) -> None:
-        state = self._state_datastore.load_data()
-        if state:
-            self._i = state[-1]
+    def set_state(self, state: Any) -> None:
+        self._i = state
 
     def __next__(self) -> Any:
         try:

--- a/fms_dgt/dataloaders/default.py
+++ b/fms_dgt/dataloaders/default.py
@@ -2,6 +2,7 @@
 from typing import Any
 
 # Local
+from fms_dgt.base.block import DATASET_TYPE
 from fms_dgt.base.dataloader import BaseDataloader
 from fms_dgt.base.datastore import BaseDatastore
 from fms_dgt.base.registry import register_dataloader
@@ -13,20 +14,25 @@ class DefaultDataloader(BaseDataloader):
 
     def __init__(
         self,
-        datastore: BaseDatastore = None,
+        data: DATASET_TYPE,
+        state_datastore: BaseDatastore = None,
         loop_over_data: bool = True,
+        **kwargs: Any,
     ) -> None:
-        super().__init__()
-        self._data = datastore.load_dataset()
+        super().__init__(**kwargs)
+
+        self._data = data
+        self._state_datastore = state_datastore
         self._i = 0
         self._loop_over_data = loop_over_data
 
-    def get_state(self) -> int:
-        return self._i
+    def save_state(self) -> None:
+        self._state_datastore.save_data([self._i])
 
-    def set_state(self, state: int) -> None:
-        if state is not None:
-            self._i = state
+    def load_state(self) -> None:
+        state = self._state_datastore.load_data()
+        if state:
+            self._i = state[-1]
 
     def __next__(self) -> Any:
         try:

--- a/fms_dgt/datastores/default.py
+++ b/fms_dgt/datastores/default.py
@@ -26,7 +26,7 @@ class DefaultDatastore(BaseDatastore):
         output_dir: str = None,
         data_format: str = "jsonl",
         restart: bool = False,
-        examples: List[T] = None,
+        data: List[T] = None,
         data_path: str = None,
         data_split: str = "train",
         **kwargs,
@@ -40,7 +40,7 @@ class DefaultDatastore(BaseDatastore):
         )
         self._data_path = data_path
         self._data_split = data_split
-        self._examples = examples or []
+        self._data = data or []
         if restart and os.path.exists(self._output_path):
             os.remove(self._output_path)
 
@@ -61,7 +61,7 @@ class DefaultDatastore(BaseDatastore):
 
     def load_data(self) -> List[T]:
 
-        data = self._examples
+        data = self._data
         loaded_data = []
         data_path = self._data_path if self._data_path else self._output_path
 

--- a/fms_dgt/datastores/default.py
+++ b/fms_dgt/datastores/default.py
@@ -1,7 +1,8 @@
 # Standard
-from typing import Any, List, TypeVar
+from typing import List, TypeVar
 import json
 import os
+import shutil
 
 # Third Party
 import datasets
@@ -23,129 +24,65 @@ class DefaultDatastore(BaseDatastore):
     def __init__(
         self,
         output_dir: str = None,
-        store_name: str = None,
-        output_format: str = "jsonl",
+        data_format: str = "jsonl",
         restart: bool = False,
-        seed_examples: List[T] = None,
+        examples: List[T] = None,
         data_path: str = None,
-        hf_path: List = None,
         data_split: str = "train",
         **kwargs,
     ) -> None:
-        super().__init__()
+        super().__init__(**kwargs)
 
-        if not os.path.exists(output_dir):
-            os.makedirs(output_dir, exist_ok=True)
-
-        self._output_dir = self._get_default_output_dir(output_dir, store_name)
-        self._output_path = os.path.join(self._output_dir, "outputs." + output_format)
-        self._final_output_path = os.path.join(
-            self._output_dir, "final_outputs." + output_format
+        self._output_path = (
+            os.path.join(output_dir, self.store_name + "." + data_format)
+            if output_dir
+            else None
         )
-        self._state_path = os.path.join(self._output_dir, "dataloader_state.txt")
-        self._dataset_path = data_path
-        self._hf_args = hf_path
-        if type(self._hf_args) == str:
-            self._hf_args = [self._hf_args]
-        self._dataset_split = data_split
-        self._seed_examples = seed_examples or []
+        self._data_path = data_path
+        self._data_split = data_split
+        self._examples = examples or []
+        if restart and os.path.exists(self._output_path):
+            os.remove(self._output_path)
 
-        if self._dataset_path and self._hf_args:
-            raise ValueError(
-                "Cannot set both 'data_path' and 'hf_args' in datastore config"
-            )
+        os.makedirs(output_dir, exist_ok=True)
 
-        if restart and os.path.exists(self.output_path):
-            os.remove(self.output_path)
+    def save_data(self, new_data: List[T]) -> None:
 
-        # always delete instruction output path because it's regenerated from machine_data
-        if os.path.exists(self._final_output_path):
-            os.remove(self._final_output_path)
+        data_format = os.path.splitext(self._output_path)[-1]
 
-    @property
-    def output_path(self) -> str:
-        return self._output_path
-
-    def _get_default_output_dir(self, output_dir: str, store_name: str):
-        path_components = []
-        path_components.append(output_dir)
-        path_components.append(store_name.replace("->", "__"))
-        return os.path.join(*path_components)
-
-    def save_data(
-        self,
-        new_data: List[T],
-        output_path: str = None,
-    ) -> None:
-
-        output_path = output_path if output_path is not None else self.output_path
-        output_format = os.path.splitext(output_path)[-1]
-
-        if output_format == ".jsonl":
-            _write_json(new_data, output_path)
-        elif output_format == ".parquet":
-            _write_parquet(new_data, output_path)
+        if data_format == ".jsonl":
+            _write_json(new_data, self._output_path)
+        elif data_format == ".yaml":
+            raise NotImplementedError
+        elif data_format == ".parquet":
+            _write_parquet(new_data, self._output_path)
         else:
-            raise ValueError(f"Unhandled output format: {output_format}")
+            raise ValueError(f"Unhandled data format: {data_format}")
 
-    def load_data(self, output_path: str = None) -> List[T]:
+    def load_data(self) -> List[T]:
 
-        output_path = output_path if output_path is not None else self.output_path
+        data = self._examples
+        loaded_data = []
+        data_path = self._data_path if self._data_path else self._output_path
 
-        if not os.path.exists(output_path):
-            return
-
-        output_format = os.path.splitext(output_path)[-1]
-        if output_format == ".jsonl":
-            machine_data = _read_json(output_path)
-        elif output_format == ".parquet":
-            machine_data = _read_parquet(output_path)
-        else:
-            raise ValueError(f"Unhandled output format: {output_format}")
-
-        return machine_data
-
-    def load_dataset(self) -> List[T]:
-
-        seed_data = self._seed_examples
-        data = []
-
-        if self._dataset_path:
-            if self._dataset_path.endswith(".json"):
-                data = _read_json(self._dataset_path)
-            elif self._dataset_path.endswith(".yaml"):
-                data = _read_yaml(self._dataset_path)
-            elif self._dataset_path.endswith(".parquet"):
-                data = _read_parquet(self._dataset_path)
-            elif os.path.isdir(self._dataset_path):
-                data = _read_huggingface([self._dataset_path], self._dataset_split)
+        if type(data_path) == list:
+            loaded_data = _read_huggingface(data_path, self._data_split)
+        elif os.path.exists(data_path):
+            output_format = os.path.splitext(data_path)[-1]
+            if output_format == ".jsonl":
+                loaded_data = _read_json(data_path)
+            elif output_format == ".yaml":
+                loaded_data = _read_yaml(data_path)
+            elif output_format == ".parquet":
+                loaded_data = _read_parquet(data_path)
+            elif os.path.isdir(data_path):
+                loaded_data = _read_huggingface([data_path], self._data_split)
             else:
-                raise ValueError(f"Unhandled data path input [{self._dataset_path}]")
-        elif self._hf_args:
-            data = _read_huggingface(self._hf_args, self._dataset_split)
+                raise ValueError(f"Unhandled output format: {output_format}")
 
-        seed_data = _add_seed_data(data, seed_data)
+        data = _join_data(loaded_data, data)
 
-        return seed_data
-
-    def save_task(self) -> None:
-        pass
-
-    def load_task(self) -> Any:
-        pass
-
-    def save_state(self, state: Any) -> None:
-        with open(self._state_path, "w") as f:
-            json.dump([state], f)
-
-    def load_state(self) -> Any:
-        if os.path.exists(self._state_path):
-            with open(self._state_path, "r") as f:
-                return json.load(f)[0]
-
-    def save_instruction_data(self, new_data: List[T]) -> None:
-        "Saves instruction data to specified location"
-        self.save_data(new_data=new_data, output_path=self._final_output_path)
+        return data
 
 
 ###
@@ -198,7 +135,7 @@ def _read_huggingface(dataset_args: List[str], split: str):
     return data
 
 
-def _add_seed_data(dataset: DATASET_TYPE, seed_data: List):
+def _join_data(dataset: DATASET_TYPE, seed_data: List):
     if seed_data:
         if type(dataset) == list:
             dataset = dataset + seed_data

--- a/fms_dgt/utils.py
+++ b/fms_dgt/utils.py
@@ -244,14 +244,14 @@ def read_data_file(file_path: str):
         contents = load_yaml_config(file_path)
 
         if not contents:
-            sdg_logger.warn("Skipping %s because it is empty!", file_path)
+            sdg_logger.warning("Skipping %s because it is empty!", file_path)
             return None
 
         if file_path.startswith("." + os.sep):
             file_path = file_path[len("." + os.sep) :]
 
         # get seed instruction data
-        task_name = "->".join(sanitize_path(os.path.dirname(file_path)).split(os.sep))
+        task_name = "__".join(sanitize_path(os.path.dirname(file_path)).split(os.sep))
         data_builder = contents.get("data_builder", "simple")
         created_by = contents.get("created_by", "")
         seed_examples = contents.pop("seed_examples", [dict()])
@@ -261,7 +261,6 @@ def read_data_file(file_path: str):
                 "data_builder": data_builder,
                 "created_by": created_by,
                 "seed_examples": seed_examples,
-                "file_path": file_path,
             },
             **contents,
         }

--- a/tests/dataloaders/test_default.py
+++ b/tests/dataloaders/test_default.py
@@ -1,24 +1,18 @@
 # Local
 from fms_dgt.dataloaders.default import DefaultDataloader
-from fms_dgt.datastores.default import DefaultDatastore
 
 
-class TestDefaultDataloader:
-    def test_iterate(self):
-        test_data = [*list(range(10))]
-        dl = DefaultDataloader(
-            datastore=DefaultDatastore(
-                output_dir="output", store_name="test_store", seed_examples=test_data
-            )
-        )
-        for i in range(20):
-            try:
-                val = next(dl)
-            except StopIteration:
-                val = None
-            if i == 10:
-                assert val == None, f"expected None but got {val}"
-            elif i > 10:
-                assert (i - 1) % 10 == val, f"expected {(i-1) % 10} but got {val}"
-            elif i < 10:
-                assert i % 10 == val, f"expected {i} but got {val}"
+def test_iterate():
+    test_data = [*list(range(10))]
+    dl = DefaultDataloader(data=test_data)
+    for i in range(20):
+        try:
+            val = next(dl)
+        except StopIteration:
+            val = None
+        if i == 10:
+            assert val == None, f"expected None but got {val}"
+        elif i > 10:
+            assert (i - 1) % 10 == val, f"expected {(i-1) % 10} but got {val}"
+        elif i < 10:
+            assert i % 10 == val, f"expected {i} but got {val}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/foundation-model-stack/fms-sdg/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

## Related Issue
Supports #ISSUE_NUMBER

## Related PRs
This PR is not dependent on any other PR

## What this PR does / why we need it

This is a fairly large PR that overhauls how we were doing datastores. We shift them from being experiment-level objects (i.e., one datastore for your entire SDG run) to method-level objects (i.e., a different, small datastore for each small task needed to be done). In addition, this PR introduces experiment cards, which are identifiers for an SDG run

## Special notes for your reviewer

## If applicable**
- [ ] this PR contains documentation
- [X] this PR contains unit tests
- [X] this PR has been tested for backwards compatibility
