### PR TITLE
feat: allow lm_judge generation and result to be separate fields

### DIFF
--- a/fms_dgt/blocks/validators/lm_judge.py
+++ b/fms_dgt/blocks/validators/lm_judge.py
@@ -54,7 +54,7 @@ class LMJudgeValidator(BaseValidatorBlock):
             )
             success_func = args[0]
 
-            lm_res = self.get_result(llm_output, self._llm_generator.result_field)
+            lm_res = self._llm_generator.get_result(llm_output, lm_result_field)
             new_result = success_func(lm_res)
             if new_result or not self._filter_invalids:
                 self.write_result(llm_output, new_result, result_field=result_field)

--- a/fms_dgt/blocks/validators/lm_judge.py
+++ b/fms_dgt/blocks/validators/lm_judge.py
@@ -54,7 +54,7 @@ class LMJudgeValidator(BaseValidatorBlock):
             )
             success_func = args[0]
 
-            lm_res = self.get_result(llm_output, result_field)
+            lm_res = self.get_result(llm_output, self._llm_generator.result_field)
             new_result = success_func(lm_res)
             if new_result or not self._filter_invalids:
                 self.write_result(llm_output, new_result, result_field=result_field)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/foundation-model-stack/fms-sdg/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

## What this PR does / why we need it
Currently, the LM judge output gets overwritten by the result of success_func. This allows for the generation and result to be in separate fields and accessible in case we want to retain the explanation generated by the LM. 

## Special notes for your reviewer

## If applicable**
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
