### PR TITLE
feat: add ability to load parquet/jsonl tables with include keyword

### DIFF
--- a/fms_dgt/utils.py
+++ b/fms_dgt/utils.py
@@ -11,6 +11,7 @@ import logging
 import os
 
 # Third Party
+import pandas as pd
 import yaml
 
 log_level = getattr(logging, os.getenv("LOG_LEVEL", "info").upper())
@@ -126,6 +127,8 @@ def load_yaml_config(yaml_path=None, yaml_config=None, yaml_dir=None, mode="full
         try:
             if path.endswith(".yaml"):
                 data = load_yaml_config(yaml_path=path, mode=mode)
+            elif path.endswith(".parquet"):
+                data = pd.read_parquet(path, engine="fastparquet").to_dict("records")
             else:
                 with open(path, "r") as f:
                     data = f.read()

--- a/fms_dgt/utils.py
+++ b/fms_dgt/utils.py
@@ -129,6 +129,12 @@ def load_yaml_config(yaml_path=None, yaml_config=None, yaml_dir=None, mode="full
                 data = load_yaml_config(yaml_path=path, mode=mode)
             elif path.endswith(".parquet"):
                 data = pd.read_parquet(path, engine="fastparquet").to_dict("records")
+            elif path.endswith(".jsonl"):
+                data = []
+                with open(path, "r", encoding="utf-8") as file:
+                    for line in file:
+                        json_obj = json.loads(line)
+                        data.append(json_obj)
             else:
                 with open(path, "r") as f:
                     data = f.read()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/foundation-model-stack/fms-sdg/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

## Related Issue
Supports #ISSUE_NUMBER

## Related PRs
This PR is not dependent on any other PR

## What this PR does / why we need it
Currently we can pass arbitrary documents in markdown or text format in task yamls using the `include` keyword like this:
```yaml
include: 
  documents:
    doc_1: documents/doc_1.md
    doc_2: documents/doc_2.md
    doc_3: documents/doc_3.txt
```
This PR adds support for passing data from parquet tables or jsonl records with the `include` keyword:
```yaml
include: 
  documents:
    doc_1: documents/doc_1.md
    doc_2: documents/doc_2.md
    doc_3: documents/doc_3.txt
  parquet_tables:
    table_1: documents/table_1.parquet
    table_2: documents/table_2.parquet
  jsonl_documents:
    jsonl_1: documents/jsonl_doc_1.jsonl
    jsonl_2: documents/jsonl_doc_1.jsonl
```
It passes the loaded parquet table to the task object as a list of records. So it can be accessed within the task init as:

```python
class ExampleSdgTask(SdgTask):
  def __init__(
          self,
          *args: Any,
          documents: Dict = None,
          parquet_tables: Dict = None,
          jsonl_documents: Dict = None,
          **kwargs: Any,
      ):
        # parse parquet data
        table_1_records = parquet_tables["table_1"]
        table_2_records = parquet_tables["table_2"]

        # parse jsonls data
        jsonl_1_docs = jsonl_documents["jsonl_1"]
        jsonl_2_docs = jsonl_documents["jsonl_2"]
```

## Special notes for your reviewer

## If applicable**
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
