### PR TITLE
Fix watsonx Model class deprecation warnings

### DIFF
--- a/fms_dgt/blocks/generators/watsonx.py
+++ b/fms_dgt/blocks/generators/watsonx.py
@@ -15,11 +15,11 @@ import fms_dgt.blocks.generators.utils as generator_utils
 try:
     # Third Party
     from ibm_watsonx_ai import Credentials
+    from ibm_watsonx_ai.foundation_models import ModelInference as Model
     from ibm_watsonx_ai.foundation_models.schema import (
         ReturnOptionProperties,
         TextGenParameters,
     )
-    from ibm_watsonx_ai.foundation_models import ModelInference as Model
 except ModuleNotFoundError:
     pass
 

--- a/fms_dgt/blocks/generators/watsonx.py
+++ b/fms_dgt/blocks/generators/watsonx.py
@@ -15,11 +15,11 @@ import fms_dgt.blocks.generators.utils as generator_utils
 try:
     # Third Party
     from ibm_watsonx_ai import Credentials
-    from ibm_watsonx_ai.foundation_models import Model
     from ibm_watsonx_ai.foundation_models.schema import (
         ReturnOptionProperties,
         TextGenParameters,
     )
+    from ibm_watsonx_ai.foundation_models import ModelInference as Model
 except ModuleNotFoundError:
     pass
 


### PR DESCRIPTION
## Related Issue
closes #177 

## Related PRs
This PR is not dependent on any other PR

## What this PR does / why we need it

To fix the deprecation warnings

## Special notes for your reviewer

Was tested locally using with `fms_dgt/databuilders/generation/simple/simple.yaml` (block type : watsonx) and running the following command : 
```
python -m fms_dgt.__main__ --data-paths data/generation/logical_reasoning/causal/qna.yaml --restart
```

## If applicable**
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
