### PR TITLE
updated the docstrings of template generator/validator

### DIFF
--- a/templates/generator/template.py
+++ b/templates/generator/template.py
@@ -12,7 +12,7 @@ from fms_dgt.base.registry import register_block
 
 @register_block("template_generator")
 class TemplateGenerator(BaseGeneratorBlock):
-    """Base Class for all Generators"""
+    """TODO: Copy and edit this template to implement your own generator class"""
 
     def __init__(self, name: str, config: Dict, **kwargs: Any) -> None:
         super().__init__(name, config, **kwargs)

--- a/templates/validator/template.py
+++ b/templates/validator/template.py
@@ -12,7 +12,7 @@ from fms_dgt.base.registry import register_block
 
 @register_block("template_validator")
 class TemplateValidator(BaseValidatorBlock):
-    """Base Class for all Validators"""
+    """TODO: Copy and edit this template to implement your own validator class"""
 
     def __init__(self, name: str, config: Dict) -> None:
         super().__init__(name, config)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/foundation-model-stack/fms-sdg/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

## Related Issue
Supports #ISSUE_NUMBER

## Related PRs
This PR is not dependent on any other PR

## What this PR does / why we need it
I simply updated the template docstring.

Although this PR may not seem important, it could have a significant effect of encouraging the authors to write a proper docstring; The original docstrings, e.g. `"""Base Class for all Generators"""`, are not clearly stating that they originate from the template. In constrast, the new docstring clearly conveys the message `"""TODO: Copy and edit this template to implement your own validator class"""`.

## Special notes for your reviewer

## If applicable**
- [x] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
